### PR TITLE
it's impossible to filter by a boolean

### DIFF
--- a/src/filter/validation.schema.ts
+++ b/src/filter/validation.schema.ts
@@ -14,7 +14,7 @@ export const schema = {
           additionalProperties: false,
           patternProperties: {
             '^[a-zA-Z].*$': {
-              type: ['string', 'number', 'null'],
+              type: ['string', 'number', 'boolean', 'null'],
             },
           },
         },
@@ -34,7 +34,7 @@ export const schema = {
             '^[a-zA-Z].*$': {
               type: 'array',
               items: {
-                type: ['string', 'number'],
+                type: ['string', 'number', 'boolean'],
               },
             },
           },
@@ -78,7 +78,7 @@ export const schema = {
           additionalProperties: false,
           properties: {
             $regex: {
-              type: 'string',
+              type: ['string', 'boolean'],
             },
           },
         },
@@ -87,7 +87,7 @@ export const schema = {
           additionalProperties: false,
           patternProperties: {
             '^[$](eq|neq)$': {
-              type: ['string', 'number', 'null'],
+              type: ['string', 'number', 'boolean', 'null'],
             },
           },
         },
@@ -107,7 +107,7 @@ export const schema = {
             '^[$](in|nin)$': {
               type: 'array',
               items: {
-                type: ['string', 'number'],
+                type: ['string', 'number', 'boolean'],
               },
             },
           },

--- a/src/filter/validation.schema.ts
+++ b/src/filter/validation.schema.ts
@@ -78,7 +78,7 @@ export const schema = {
           additionalProperties: false,
           properties: {
             $regex: {
-              type: ['string'],
+              type: 'string',
             },
           },
         },

--- a/src/filter/validation.schema.ts
+++ b/src/filter/validation.schema.ts
@@ -78,7 +78,7 @@ export const schema = {
           additionalProperties: false,
           properties: {
             $regex: {
-              type: ['string', 'boolean'],
+              type: ['string'],
             },
           },
         },

--- a/src/filter/validator.spec.ts
+++ b/src/filter/validator.spec.ts
@@ -9,7 +9,9 @@ describe('Validator', () => {
       const queries = [
         { mimetype: null },
         { mimetype: 'audio' },
-        { mimetype: ['audio', 'video'] },
+        { mimetype: ['audio', 'video', true] },
+        { mimetype: true },
+        { mimetype: { $eq: true } },
         { mimetype: { $eq: 'audio' } },
         { mimetype: { $regex: '^audio/' } },
         { mimetype: { $in: ['audio/mp3', 'aduio/mp4'] } },


### PR DESCRIPTION
ex:
?filter={"isSponsor": true} = fail

now it's possible to filter with a direct boolean, $eq, $neq $in, $nin, array