### PR TITLE
fix: use property own name instead of exposed one

### DIFF
--- a/src/sorter/parser.spec.ts
+++ b/src/sorter/parser.spec.ts
@@ -15,42 +15,75 @@ class TestSortProps extends CollectionProperties {
   readonly unsortable: string;
 }
 
+class TestSortPropsWithNameChangeDefault extends CollectionProperties {
+  @Expose({ name: 'createdAt', sortable: true, default: true })
+  readonly created_at: 'desc' | 'asc';
+
+  @Expose({ sortable: true })
+  readonly userName: 'desc' | 'asc';
+
+  readonly unsortable: string;
+}
+
+class TestSortPropsWithoutDefaults extends CollectionProperties {
+  @Expose({ name: 'createdAt', sortable: true })
+  readonly created_at: 'desc' | 'asc';
+
+  @Expose({ sortable: true })
+  readonly userName: 'desc' | 'asc';
+
+  readonly unsortable: string;
+}
+
 describe('Sorter', () => {
   describe('Parser', () => {
     describe('with allowed keys', () => {
-      it('should process known property', () => {
-        const sParam = new SorterParser(TestSortProps).parse('userName');
+      describe('without property name change', () => {
+        it('should process known property', () => {
+          const sParam = new SorterParser(TestSortProps).parse('userName');
 
-        expect(sParam).toHaveProperty('userName');
-        expect(sParam['userName']).toEqual('asc');
+          expect(sParam).toHaveProperty('userName');
+          expect(sParam['userName']).toEqual('asc');
+        });
+
+        it('should process known property descending', () => {
+          const sParam = new SorterParser(TestSortProps).parse('-userName');
+
+          expect(sParam).toHaveProperty('userName');
+          expect(sParam['userName']).toEqual('desc');
+        });
+
+        it('should respond with default property for empty string', () => {
+          const sParam = new SorterParser(TestSortProps).parse('');
+
+          expect(sParam).toHaveProperty('userName');
+          expect(sParam['userName']).toEqual('asc');
+        });
       });
 
-      it('should process known property with the prop name change', () => {
-        const sParam = new SorterParser(TestSortProps).parse('createdAt');
+      describe('with property name change', () => {
+        it('should process known property', () => {
+          const sParam = new SorterParser(TestSortProps).parse('createdAt');
 
-        expect(sParam).toHaveProperty('created_at');
-        expect(sParam['created_at']).toEqual('asc');
-      });
+          expect(sParam).toHaveProperty('created_at');
+          expect(sParam['created_at']).toEqual('asc');
+        });
 
-      it('should process known property descending', () => {
-        const sParam = new SorterParser(TestSortProps).parse('-userName');
+        it('should process known property', () => {
+          const sParam = new SorterParser(TestSortProps).parse('-createdAt');
 
-        expect(sParam).toHaveProperty('userName');
-        expect(sParam['userName']).toEqual('desc');
-      });
+          expect(sParam).toHaveProperty('created_at');
+          expect(sParam['created_at']).toEqual('desc');
+        });
 
-      it('should process known property with the prop name change', () => {
-        const sParam = new SorterParser(TestSortProps).parse('-createdAt');
+        it('should respond with default property for empty string', () => {
+          const sParam = new SorterParser(
+            TestSortPropsWithNameChangeDefault,
+          ).parse('');
 
-        expect(sParam).toHaveProperty('created_at');
-        expect(sParam['created_at']).toEqual('desc');
-      });
-
-      it('should process known property with the prop name change', () => {
-        const sParam = new SorterParser(TestSortProps).parse('');
-
-        expect(sParam).toHaveProperty('userName');
-        expect(sParam['userName']).toEqual('asc');
+          expect(sParam).toHaveProperty('created_at');
+          expect(sParam['created_at']).toEqual('asc');
+        });
       });
     });
 
@@ -60,6 +93,22 @@ describe('Sorter', () => {
           new SorterParser(TestSortProps).parse('-updatedAt');
         };
         expect(sorter).toThrow(SortValidationError);
+      });
+    });
+
+    describe('without default sort provided', () => {
+      it('should be created_at property for an empty string', () => {
+        const sParam = new SorterParser(TestSortPropsWithoutDefaults).parse('');
+
+        expect(sParam).toHaveProperty('created_at');
+        expect(sParam['created_at']).toEqual('asc');
+      });
+
+      it('should be created_at property without providing any value', () => {
+        const sParam = new SorterParser(TestSortPropsWithoutDefaults).parse();
+
+        expect(sParam).toHaveProperty('created_at');
+        expect(sParam['created_at']).toEqual('asc');
       });
     });
   });

--- a/src/sorter/parser.ts
+++ b/src/sorter/parser.ts
@@ -9,7 +9,6 @@ export class SorterParser {
   parse(sortProp?: string): SortableParameters {
     const sortableParameters: SortableParameters = {};
     const props = sortProp !== undefined ? sortProp.split(';') : [];
-
     props
       .filter((v) => isNotEmpty(v))
       .forEach((name: string) => {
@@ -28,9 +27,9 @@ export class SorterParser {
 
   private get defaultSort(): string {
     const props = this.collectionPropsClass.prototype.__props;
-    return (
-      Object.keys(props).filter((key) => props[key].default)[0] ?? 'created_at'
-    );
+    const key = Object.keys(props).filter((key) => props[key].default)[0];
+
+    return key ? props[key].name : 'created_at';
   }
 
   private validateProperty(prop: string) {

--- a/src/test/test.controller.ts
+++ b/src/test/test.controller.ts
@@ -22,7 +22,6 @@ export class TestController {
     @Query(new ValidationPipe(MyCollectionProperties))
     collectionDto: CollectionDto,
   ): Promise<CollectionResponse<any>> {
-    console.log(collectionDto);
     return { data: [], pagination: { total: 1, limit: 10, page: 0 } };
   }
 }


### PR DESCRIPTION
In a case when an exposed name is different than a property own name we should use the latter to sort entities. This PR fixes the bug.